### PR TITLE
Fix: Prevent information leakage in incomplete information games

### DIFF
--- a/games/bargaining/bargaining.py
+++ b/games/bargaining/bargaining.py
@@ -23,17 +23,26 @@ class BargainingGame(Game):
         self.show_inflation_update = show_inflation_update
 
         # Pass game parameters to players
-        game_params = {
+        # Shared parameters for all players
+        base_game_params = {
             "money_to_divide": money_to_divide,
             "max_rounds": max_rounds,
             "complete_information": complete_information,
-            "messages_allowed": messages_allowed,
-            "show_inflation_update": show_inflation_update,
-            "delta_1": self.delta_1,
-            "delta_2": self.delta_2
+            "messages_allowed": messages_allowed
         }
-        self.player_1.set_game_params(game_params)
-        self.player_2.set_game_params(game_params)
+
+        # Player-specific parameters
+        if complete_information:
+            # In complete information mode, both players know both deltas
+            player_1_params = {**base_game_params, "delta_player_1": self.delta_1, "delta_player_2": self.delta_2}
+            player_2_params = {**base_game_params, "delta_player_1": self.delta_1, "delta_player_2": self.delta_2}
+        else:
+            # In incomplete information mode, each player only knows their own delta
+            player_1_params = {**base_game_params, "delta_player_1": self.delta_1}
+            player_2_params = {**base_game_params, "delta_player_2": self.delta_2}
+
+        self.player_1.set_game_params(player_1_params)
+        self.player_2.set_game_params(player_2_params)
 
         assert player_1.public_name != player_2.public_name, "Players should have different names"
 

--- a/games/negotiation/negotiation.py
+++ b/games/negotiation/negotiation.py
@@ -54,6 +54,36 @@ class NegotiationGame(Game):
         self.player_1.act_name = "sell the product"
         self.player_2.act_name = "buy the product"
 
+        # Pass game parameters to players
+        base_game_params = {
+            "max_rounds": max_rounds,
+            "complete_information": complete_information,
+            "product_price_order": product_price_order,
+            "messages_allowed": messages_allowed
+        }
+
+        if complete_information:
+            # Both players know each other's values
+            player_1_params = {
+                **base_game_params,
+                "role": "seller",
+                "seller_value": seller_value,
+                "buyer_value": buyer_value
+            }
+            player_2_params = {
+                **base_game_params,
+                "role": "buyer",
+                "seller_value": seller_value,
+                "buyer_value": buyer_value
+            }
+        else:
+            # Each player only knows their own value
+            player_1_params = {**base_game_params, "role": "seller", "seller_value": seller_value}
+            player_2_params = {**base_game_params, "role": "buyer", "buyer_value": buyer_value}
+
+        self.player_1.set_game_params(player_1_params)
+        self.player_2.set_game_params(player_2_params)
+
         # Store game params for error logging
         game_params = {
             "max_rounds": max_rounds,

--- a/games/persuasion/persuasion.py
+++ b/games/persuasion/persuasion.py
@@ -50,6 +50,43 @@ class PersuasionGame(Game):
         self.set_rules(os.path.join(path, 'rules_prompt.json'), p_info, 'p2')
         self.player_1.req_offer_text, self.player_2.req_offer_text = self.build_offer_prompt()
 
+        # Pass game parameters to players
+        base_game_params = {
+            "is_myopic": is_myopic,
+            "product_price": product_price,
+            "total_rounds": total_rounds,
+            "seller_message_type": seller_message_type,
+            "allow_buyer_message": allow_buyer_message
+        }
+
+        # Player 1 is seller, Player 2 is buyer
+        seller_params = {
+            **base_game_params,
+            "role": "seller",
+            "p": p  # Seller always knows p
+        }
+
+        buyer_params = {
+            **base_game_params,
+            "role": "buyer"
+        }
+
+        # Add c, v to seller only if they should know
+        if is_seller_know_cv:
+            seller_params["c"] = c
+            seller_params["v"] = v
+
+        # Add p to buyer only if they should know
+        if is_buyer_know_p:
+            buyer_params["p"] = p
+
+        # Add c, v to buyer - they always know their own valuations
+        buyer_params["c"] = c
+        buyer_params["v"] = v
+
+        self.player_1.set_game_params(seller_params)
+        self.player_2.set_game_params(buyer_params)
+
         # Store game params for error logging
         game_params = {
             "is_myopic": is_myopic,

--- a/players/http_player.py
+++ b/players/http_player.py
@@ -1,3 +1,17 @@
+"""
+HTTP Player for GLEE framework.
+
+This player sends game state and parameters to an external HTTP server endpoint,
+which can implement custom game-playing logic.
+
+Note on game_params changes:
+- Bargaining: Parameter names changed from delta_1/delta_2 to delta_player_1/delta_player_2
+  In incomplete information mode, each player receives only their own delta parameter.
+- Negotiation: Now receives game_params with seller_value/buyer_value (filtered per player)
+- Persuasion: Now receives game_params with c,v,p (filtered based on information settings)
+
+HTTP servers should use game_params.get() for safe access to these parameters.
+"""
 import requests
 import json
 import os


### PR DESCRIPTION
This commit addresses a security vulnerability where HTTP players could access opponent's private information through game_params in incomplete information scenarios.

Changes:
- Bargaining: Filter delta parameters per player (delta_player_1/delta_player_2)
- Negotiation: Add game_params with per-player value filtering
- Persuasion: Add game_params with conditional c,v,p filtering

In incomplete information mode, players now only receive their own private parameters, preventing information leakage to HTTP clients.

Breaking change: Bargaining parameter names changed from delta_1/delta_2 to delta_player_1/delta_player_2. Removed show_inflation_update from game_params (it's a display setting, not a game parameter).