### PR TITLE
feat: Add HuggingFace player for local model inference

### DIFF
--- a/main.py
+++ b/main.py
@@ -30,7 +30,11 @@ def create_players(config):
         p2_args['delta'] = default_delta_2
 
     p1 = player_factory(config.get('player_1_type', 'terminal'), p1_args)
-    if config.get('player_2_type', 'terminal') == 'hf' and config.get('player_1_type', 'terminal') == 'hf':
+    # Support model sharing for HuggingFace players (both 'hf' and 'huggingface' types)
+    hf_types = ('hf', 'huggingface')
+    p1_type = config.get('player_1_type', 'terminal')
+    p2_type = config.get('player_2_type', 'terminal')
+    if p1_type in hf_types and p2_type in hf_types:
         if (p1_args.get('model_name', None) == p2_args.get('model_name', None) and
                 p1_args.get('model_name', None) is not None):
             p2_args['load_hf_model'] = False

--- a/players/huggingface_player.py
+++ b/players/huggingface_player.py
@@ -1,0 +1,231 @@
+"""
+HuggingFace Player - loads and runs local HuggingFace models for GLEE games.
+Supports quantization (4-bit/8-bit) and various model configurations.
+"""
+
+from players.base_player import Player
+from utils.conversation import Conversation
+import os
+
+
+class HuggingFacePlayer(Player):
+    """
+    Player that uses locally loaded HuggingFace models.
+
+    Required kwargs:
+        model_name: HuggingFace model name or local path
+
+    Optional kwargs:
+        device: "cuda" / "cpu" / "auto" (default: "auto")
+        max_new_tokens: Maximum tokens to generate (default: 512)
+        quantization: None / "4bit" / "8bit" (default: None)
+        torch_dtype: "float16" / "bfloat16" / "float32" (default: "float16")
+        trust_remote_code: Whether to trust remote code (default: False)
+        temperature: Sampling temperature (default: 0.7)
+        do_sample: Whether to sample (default: True)
+        top_p: Top-p sampling parameter (default: 0.9)
+        load_hf_model: Whether to load the model (default: True) - set False to share model
+    """
+
+    def __init__(self, public_name, delta=1, player_id=0, **kwargs):
+        super().__init__(public_name, delta, player_id)
+
+        assert 'model_name' in kwargs, 'model_name must be provided'
+
+        self.model_name = kwargs['model_name']
+        self.device = kwargs.get('device', 'auto')
+        self.max_new_tokens = kwargs.get('max_new_tokens', 512)
+        self.quantization = kwargs.get('quantization', None)
+        self.torch_dtype_str = kwargs.get('torch_dtype', 'float16')
+        self.trust_remote_code = kwargs.get('trust_remote_code', False)
+        self.temperature = kwargs.get('temperature', 0.7)
+        self.do_sample = kwargs.get('do_sample', True)
+        self.top_p = kwargs.get('top_p', 0.9)
+        self.load_hf_model = kwargs.get('load_hf_model', True)
+
+        # Conversation management
+        self.conv = Conversation("huggingface", roles=("user", "assistant"))
+        self.user_name = "user"
+
+        # Model and tokenizer (loaded lazily or shared)
+        self.model = None
+        self.tokenizer = None
+
+        if self.load_hf_model:
+            self._load_model()
+
+    def _load_model(self):
+        """Load the HuggingFace model and tokenizer."""
+        import torch
+        from transformers import AutoModelForCausalLM, AutoTokenizer
+
+        print(f"Loading model: {self.model_name}")
+
+        # Determine torch dtype
+        dtype_map = {
+            'float16': torch.float16,
+            'bfloat16': torch.bfloat16,
+            'float32': torch.float32,
+        }
+        torch_dtype = dtype_map.get(self.torch_dtype_str, torch.float16)
+
+        # Load tokenizer
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            self.model_name,
+            trust_remote_code=self.trust_remote_code
+        )
+
+        # Set pad token if not set
+        if self.tokenizer.pad_token is None:
+            self.tokenizer.pad_token = self.tokenizer.eos_token
+
+        # Prepare model loading kwargs
+        model_kwargs = {
+            'trust_remote_code': self.trust_remote_code,
+            'torch_dtype': torch_dtype,
+        }
+
+        # Handle device mapping
+        if self.device == 'auto':
+            model_kwargs['device_map'] = 'auto'
+        elif self.device == 'cpu':
+            model_kwargs['device_map'] = 'cpu'
+        else:
+            model_kwargs['device_map'] = self.device
+
+        # Configure quantization
+        if self.quantization in ('4bit', '8bit'):
+            try:
+                from transformers import BitsAndBytesConfig
+
+                if self.quantization == '4bit':
+                    model_kwargs['quantization_config'] = BitsAndBytesConfig(
+                        load_in_4bit=True,
+                        bnb_4bit_compute_dtype=torch_dtype,
+                        bnb_4bit_use_double_quant=True,
+                        bnb_4bit_quant_type="nf4"
+                    )
+                else:  # 8bit
+                    model_kwargs['quantization_config'] = BitsAndBytesConfig(
+                        load_in_8bit=True
+                    )
+                print(f"Using {self.quantization} quantization")
+            except ImportError:
+                print("Warning: bitsandbytes not installed. Loading without quantization.")
+
+        # Load model
+        self.model = AutoModelForCausalLM.from_pretrained(
+            self.model_name,
+            **model_kwargs
+        )
+
+        print(f"Model loaded successfully on device: {self.model.device}")
+
+    def add_message(self, message, role='user'):
+        """Add a message to the conversation history."""
+        if role == 'system':
+            self.conv.system_message = message
+        else:
+            self.conv.append_message(self.conv.roles[0] if role == 'user' else self.conv.roles[1], message)
+
+    def clean_conv(self):
+        """Clear the conversation history."""
+        self.conv.messages = []
+
+    def set_system_message(self, message):
+        """Set the system message for the conversation."""
+        self.conv.system_message = message
+
+    def _format_messages_for_model(self):
+        """Format messages for the model using chat template if available."""
+        messages = self.conv.to_openai_api_messages()
+
+        # Try to use the model's chat template if available
+        if hasattr(self.tokenizer, 'apply_chat_template'):
+            try:
+                formatted = self.tokenizer.apply_chat_template(
+                    messages,
+                    tokenize=False,
+                    add_generation_prompt=True
+                )
+                return formatted
+            except Exception as e:
+                print(f"Warning: Could not apply chat template: {e}")
+
+        # Fallback: simple concatenation
+        prompt = ""
+        for msg in messages:
+            role = msg['role']
+            content = msg['content']
+            if role == 'system':
+                prompt += f"System: {content}\n\n"
+            elif role == 'user':
+                prompt += f"User: {content}\n\n"
+            elif role == 'assistant':
+                prompt += f"Assistant: {content}\n\n"
+        prompt += "Assistant:"
+        return prompt
+
+    def get_text_answer(self, format_checker, decision=False):
+        """Generate a response from the model."""
+        import torch
+
+        if self.model is None or self.tokenizer is None:
+            raise RuntimeError("Model not loaded. Set load_hf_model=True or share model from another player.")
+
+        max_retries = 3
+        count = 0
+
+        while count < max_retries:
+            try:
+                # Format the prompt
+                prompt = self._format_messages_for_model()
+
+                # Tokenize
+                inputs = self.tokenizer(prompt, return_tensors="pt", truncation=True)
+                inputs = {k: v.to(self.model.device) for k, v in inputs.items()}
+
+                # Generate
+                with torch.no_grad():
+                    outputs = self.model.generate(
+                        **inputs,
+                        max_new_tokens=self.max_new_tokens,
+                        temperature=self.temperature if self.do_sample else 1.0,
+                        do_sample=self.do_sample,
+                        top_p=self.top_p if self.do_sample else 1.0,
+                        pad_token_id=self.tokenizer.pad_token_id,
+                        eos_token_id=self.tokenizer.eos_token_id,
+                    )
+
+                # Decode only the new tokens
+                input_length = inputs['input_ids'].shape[1]
+                generated_tokens = outputs[0][input_length:]
+                self.text_response = self.tokenizer.decode(generated_tokens, skip_special_tokens=True).strip()
+
+                # Check format
+                format_result = format_checker(self.text_response)
+                if isinstance(format_result, tuple):
+                    is_valid, error_msg = format_result
+                else:
+                    is_valid = format_result
+                    error_msg = "Format validation failed"
+
+                if is_valid:
+                    print(self.text_response)
+                    # Add assistant response to conversation
+                    self.conv.append_message(self.conv.roles[1], self.text_response)
+                    break
+                else:
+                    print(f"Format check failed (attempt {count + 1}/{max_retries}): {error_msg}")
+                    # Add error feedback to help model correct
+                    if count < max_retries - 1:
+                        self.conv.append_message(self.conv.roles[1], self.text_response)
+                        self.conv.append_message(self.conv.roles[0],
+                            f"Your response format was invalid: {error_msg}. Please try again with the correct format.")
+
+            except Exception as e:
+                print(f"Error during generation (attempt {count + 1}/{max_retries}): {e}")
+
+            count += 1
+
+        return self.text_response

--- a/players/player_factory.py
+++ b/players/player_factory.py
@@ -4,6 +4,7 @@ from players.otree_player import OtreePlayer
 from players.demo_player import DemoPlayer
 from players.otree_litellm_player import OtreeLiteLLMPlayer
 from players.http_player import HTTPPlayer
+from players.huggingface_player import HuggingFacePlayer
 
 
 PLAYERS = {
@@ -12,7 +13,9 @@ PLAYERS = {
     'demo': DemoPlayer,
     'otree_LLM': OtreeLiteLLMPlayer,
     'litellm': LiteLLMPlayer,
-    'http': HTTPPlayer
+    'http': HTTPPlayer,
+    'huggingface': HuggingFacePlayer,
+    'hf': HuggingFacePlayer,  # short alias
 }
 
 

--- a/requirements.in
+++ b/requirements.in
@@ -22,6 +22,12 @@ patsy
 flask
 langchain_openai
 
+# HuggingFace local model support
+torch>=2.0.0
+transformers>=4.36.0
+accelerate>=0.25.0
+bitsandbytes>=0.41.0
+
 # additional requirements for the human data collection app:
 # otree
 # psycopg2

--- a/sample_configs/bargaining/huggingface_config.json
+++ b/sample_configs/bargaining/huggingface_config.json
@@ -1,0 +1,27 @@
+{
+  "player_1_type": "huggingface",
+  "player_2_type": "huggingface",
+  "player_1_args": {
+    "public_name": "Alice",
+    "model_name": "meta-llama/Llama-3.2-1B-Instruct",
+    "device": "auto",
+    "quantization": null,
+    "max_new_tokens": 512,
+    "temperature": 0.7
+  },
+  "player_2_args": {
+    "public_name": "Bob",
+    "player_id": 3,
+    "model_name": "meta-llama/Llama-3.2-1B-Instruct"
+  },
+  "game_type": "bargaining",
+  "game_args": {
+    "money_to_divide": 1000,
+    "max_rounds": 10,
+    "complete_information": true,
+    "messages_allowed": true,
+    "show_inflation_update": true,
+    "delta_1": 1,
+    "delta_2": 0.9
+  }
+}


### PR DESCRIPTION
Add support for running games with locally-loaded HuggingFace models:

- New HuggingFacePlayer class supporting:
  - Loading models from HuggingFace Hub or local paths
  - 4-bit and 8-bit quantization via bitsandbytes
  - Model sharing between players for memory efficiency
  - Chat templates with fallback formatting

- Register 'huggingface' and 'hf' player types in factory
- Update main.py to support model sharing for both aliases
- Add torch, transformers, accelerate, bitsandbytes to requirements
- Add sample config for bargaining game

Usage example:
```json
{
  "player_1_type": "huggingface",
  "player_1_args": {
    "model_name": "meta-llama/Llama-3.2-1B-Instruct",
    "quantization": "4bit"
  }
}
```